### PR TITLE
FastMode with brighness control

### DIFF
--- a/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -112,7 +112,7 @@ bool MatrixPanel_I2S_DMA::allocateDMAmemory()
 		matrix_row_framebuffer_malloc[malloc_num] = (rowColorDepthStruct *)heap_caps_malloc( (sizeof(rowColorDepthStruct) * _num_frame_buffers) , MALLOC_CAP_DMA);
 		// If the ESP crashes here, then we must have a horribly fragmented memory space, or trying to allocate a ludicrous resolution.
  #if SERIAL_DEBUG  
-		Serial.printf("Malloc'ing %d bytes of memory @ address %d for frame row %d.\r\n", (sizeof(rowColorDepthStruct) * _num_frame_buffers), matrix_row_framebuffer_malloc[malloc_num], malloc_num);
+		Serial.printf("Malloc'ing %d bytes of memory @ address %ud for frame row %d.\r\n", (sizeof(rowColorDepthStruct) * _num_frame_buffers), (unsigned int)matrix_row_framebuffer_malloc[malloc_num], malloc_num);
  #endif	
 		if ( matrix_row_framebuffer_malloc[malloc_num] == NULL ) { 
 		        Serial.printf("ERROR: Couldn't malloc matrix_row_framebuffer %d! Critical fail.\r\n", malloc_num);            
@@ -438,108 +438,33 @@ void MatrixPanel_I2S_DMA::configureDMA(int r1_pin, int  g1_pin, int  b1_pin, int
  *
  *  Note: If you change the brightness with setBrightness() you MUST then clearScreen() and repaint / flush the entire framebuffer.
  */
-//#define GO_FOR_SPEED 1
-
-#ifdef GO_FOR_SPEED
-/* Update a specific co-ordinate in the DMA buffer */
-void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(int16_t x_coord, int16_t y_coord, uint8_t red, uint8_t green, uint8_t blue)
-{
-	
-    // Check that the co-ordinates are within range, or it'll break everything big time.
-    // Valid co-ordinates are from 0 to (MATRIX_XXXX-1)
-	if ( x_coord < 0 || y_coord < 0 || x_coord >= MATRIX_WIDTH || y_coord >= MATRIX_HEIGHT) {
-		  return;
-    }
-	
-	// https://ledshield.wordpress.com/2012/11/13/led-brightness-to-your-eye-gamma-correction-no/
-	red 	= lumConvTab[red];
-	green 	= lumConvTab[green];
-	blue 	= lumConvTab[blue]; 	
-
-    bool painting_top_frame = true;
-    if ( y_coord >= ROWS_PER_FRAME) // co-ords start at zero, y_coord = 15 = 16 (rows per frame)
-    {
-        y_coord -= ROWS_PER_FRAME;  // Subtract the ROWS_PER_FRAME from the pixel co-ord to get the panel ROW (not really the 'y_coord' anymore)
-        painting_top_frame = false;
-    }
-	
-	// We need to update the correct uint16_t in the rowBitStruct array, that gets sent out in parallel
-	// 16 bit parallel mode - Save the calculated value to the bitplane memory in reverse order to account for I2S Tx FIFO mode1 ordering
-	int rowBitStruct_x_coord_uint16_t_position = (x_coord % 2) ? (x_coord-1):(x_coord+1);
-
-	// Find the memory address for the malloc for this framebuffer row.
-	rowColorDepthStruct *fb_row_malloc_ptr = (rowColorDepthStruct *) matrix_row_framebuffer_malloc[y_coord]; 	
-	
-    for(int color_depth_idx=0; color_depth_idx<PIXEL_COLOR_DEPTH_BITS; color_depth_idx++)  // color depth - 8 iterations
-    {
-        uint8_t mask = (1 << color_depth_idx); // PWM bit colour mask (max 8bits per pixel colour)
-        
-        // The destination for the pixel bitstream 
-        //rowBitStruct *p = &matrix_framebuffer_malloc_1[back_buffer_id].rowdata[y_coord].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
-        // Get the contents at this address, cast as a rowColorDepthStruct  
-        //rowBitStruct *p = &fb_row_malloc_ptr[back_buffer_id].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
-		uint16_t &v = fb_row_malloc_ptr[back_buffer_id].rowbits[color_depth_idx].data[rowBitStruct_x_coord_uint16_t_position]; 
-		
-        //int v=0; // the output bitstream
-      
-        if (painting_top_frame) // Painting to pixel in the top half of the HUB75 panel use the R1, B1 and G1 pins
-        { 
-           // Set the colour of the pixel of interest
-		   // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
-          if (red & mask)   { v|=BIT_R1; }  else {  v &= ~(BIT_R1); }
-          if (green & mask) { v|=BIT_G1; }  else {  v &= ~(BIT_G1); }
-          if (blue & mask)  { v|=BIT_B1; }  else {  v &= ~(BIT_B1); }
-        }
-        else
-        { // Paint to a pixel in the bottom half
-	
-          if (red & mask)   { v|=BIT_R2; } else {  v &= ~(BIT_R2); }
-          if (green & mask) { v|=BIT_G2; } else {  v &= ~(BIT_G2); }
-          if (blue & mask)  { v|=BIT_B2; } else {  v &= ~(BIT_B2); }
- 
-        } // paint
-
-        // 16 bit parallel mode
-        //Save the calculated value to the bitplane memory in reverse order to account for I2S Tx FIFO mode1 ordering
-        //p->data[rowBitStruct_x_coord_uint16_t_position] = v;	
-		// NOTE: No need to do this as 'v' is now a reference directly to the frameStruct
-		
-    } // color depth loop (8)
-	
-} // updateMatrixDMABuffer (specific co-ords change)
-
-#else
 
 /* Update a specific co-ordinate in the DMA buffer */
 /* Original version were we re-create the bitstream from scratch for each x,y co-ordinate / pixel changed. Slightly slower. */
 void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(int16_t x_coord, int16_t y_coord, uint8_t red, uint8_t green, uint8_t blue)
 {
     if ( !everything_OK ) { 
-
       #if SERIAL_DEBUG 
               Serial.println("Cannot updateMatrixDMABuffer as setup failed!");
       #endif         
-      
       return;
     }
-	
-	/* LED Brightness Compensation. Because if we do a basic "red & mask" for example, 
-	 * we'll NEVER send the dimmest possible colour, due to binary skew.
-	   
-	   i.e. It's almost impossible for color_depth_idx of 0 to be sent out to the MATRIX unless the 'value' of a color is exactly '1'
-	   
-	 */	 
-	red 	= lumConvTab[red];
-	green 	= lumConvTab[green];
-	blue 	= lumConvTab[blue]; 	
 
-    
-   /* 1) Check that the co-ordinates are within range, or it'll break everything big time.
-    * Valid co-ordinates are from 0 to (MATRIX_XXXX-1)
-    */
-	  if ( x_coord < 0 || y_coord < 0 || x_coord >= MATRIX_WIDTH || y_coord >= MATRIX_HEIGHT) {
-      return;
-    }
+  /* 1) Check that the co-ordinates are within range, or it'll break everything big time.
+  * Valid co-ordinates are from 0 to (MATRIX_XXXX-1)
+  */
+  if ( x_coord < 0 || y_coord < 0 || x_coord >= MATRIX_WIDTH || y_coord >= MATRIX_HEIGHT) {
+    return;
+  }
+
+  /* LED Brightness Compensation. Because if we do a basic "red & mask" for example, 
+	 * we'll NEVER send the dimmest possible colour, due to binary skew.
+	 * i.e. It's almost impossible for color_depth_idx of 0 to be sent out to the MATRIX unless the 'value' of a color is exactly '1'
+   * https://ledshield.wordpress.com/2012/11/13/led-brightness-to-your-eye-gamma-correction-no/
+	 */
+	red   = lumConvTab[red];
+	green = lumConvTab[green];
+	blue  = lumConvTab[blue]; 	
 
 	/* When using the drawPixel, we are obviously only changing the value of one x,y position, 
 	 * however, the two-scan panels paint TWO lines at the same time
@@ -553,66 +478,69 @@ void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(int16_t x_coord, int16_t y_coord
 	 * data.
 	 */
     bool painting_top_frame = true;
-    if ( y_coord >= ROWS_PER_FRAME) // co-ords start at zero, y_coord = 15 = 16 (rows per frame)
+    if ( y_coord >= ROWS_PER_FRAME) // co-ords start at zero, y_coord = 15 => 16 (rows per frame)
     {
         y_coord -= ROWS_PER_FRAME;  // Subtract the ROWS_PER_FRAME from the pixel co-ord to get the panel ROW (not really the 'y_coord' anymore)
         painting_top_frame = false;
     }
 	
-	// We need to update the correct uint16_t in the rowBitStruct array, that gets sent out in parallel
-	int rowBitStruct_x_coord_uint16_t_position = (x_coord % 2) ? (x_coord-1):(x_coord+1);
-	
-    for(int color_depth_idx=0; color_depth_idx<PIXEL_COLOR_DEPTH_BITS; color_depth_idx++)  // color depth - 8 iterations
-    {
-        int mask = (1 << color_depth_idx); // 24 bit color
-        
-        // The destination for the pixel bitstream 
-        //rowBitStruct *p = &matrix_framebuffer_malloc_1[back_buffer_id].rowdata[y_coord].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
+    // Find the memory address for the malloc for this framebuffer row.
+    rowColorDepthStruct *fb_row_malloc_ptr = (rowColorDepthStruct *) matrix_row_framebuffer_malloc[y_coord]; 
 
-        // Find the memory address for the malloc for this framebuffer row.
-        rowColorDepthStruct *fb_row_malloc_ptr = (rowColorDepthStruct *) matrix_row_framebuffer_malloc[y_coord]; 
+    // We need to update the correct uint16_t in the rowBitStruct array, that gets sent out in parallel
+    // 16 bit parallel mode - Save the calculated value to the bitplane memory in reverse order to account for I2S Tx FIFO mode1 ordering
+    uint16_t rowBitStruct_x_coord_uint16_t_position = (x_coord % 2) ? (x_coord-1):(x_coord+1);
+
+    for(uint8_t color_depth_idx=0; color_depth_idx<PIXEL_COLOR_DEPTH_BITS; color_depth_idx++)  // color depth - 8 iterations
+    {
+        uint8_t mask = (1 << color_depth_idx); // 24 bit color
+        
         // Get the contents at this address, cast as a rowColorDepthStruct  
         rowBitStruct *p = &fb_row_malloc_ptr[back_buffer_id].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
 
+        // We need to update the correct uint16_t in the rowBitStruct array, that gets sent out in parallel
+        uint16_t &v = p->data[rowBitStruct_x_coord_uint16_t_position]; // persist what we already have
 
+        if (painting_top_frame)
+        { // Need to copy what the RGB status is for the bottom pixels
+          v &= BITSMASK_RGB1; // reset R1G1B1 bits
+          // Set the color of the pixel of interest
+          if (green & mask) {  v|=BIT_G1; }
+          if (blue & mask)  {  v|=BIT_B1; }
+          if (red & mask)   {  v|=BIT_R1; }
 
-		// int v = p->data[rowBitStruct_x_coord_uint16_t_position]; // persist what we already have
-        int v=0; // the output bitstream
-        
-        // if there is no latch to hold address, output ADDX lines directly to GPIO and latch data at end of cycle
-        int gpioRowAddress = y_coord;
-        
-        // normally output current rows ADDX, special case for LSB, output previous row's ADDX (as previous row is being displayed for one latch cycle)
-        if(color_depth_idx == 0)
-          gpioRowAddress = y_coord-1;
-        
-        if (gpioRowAddress & 0x01) v|=BIT_A; // 1
-        if (gpioRowAddress & 0x02) v|=BIT_B; // 2
-        if (gpioRowAddress & 0x04) v|=BIT_C; // 4
-        if (gpioRowAddress & 0x08) v|=BIT_D; // 8
-        if (gpioRowAddress & 0x10) v|=BIT_E; // 16
-  
-        // need to disable OE after latch to hide row transition
-        if((x_coord) == 0 ) v|=BIT_OE;
-        
+        } else { // Do it the other way around 
+          v &= BITSMASK_RGB2; // reset R2G2B2 bits
+          // Color to set
+          if (red & mask)   { v|=BIT_R2; }
+          if (green & mask) { v|=BIT_G2; }
+          if (blue & mask)  { v|=BIT_B2; }
+        } // paint
+
+        if (fastmode)
+          continue;
+
+        // update address/control bits
+        v &= BITSMASK_CTRL;      // reset ABCDE,EO,LAT address bits
+        uint16_t _y = color_depth_idx ? y_coord : y_coord -1;
+        v|=_y<<8;         // shift row coord to match ABCDE bits from 8 to 12 and set bitvector
+
         // drive latch while shifting out last bit of RGB data
         if((x_coord) == PIXELS_PER_ROW-1) v|=BIT_LAT;
-		
-        // need to turn off OE one clock before latch, otherwise can get ghosting
-        if((x_coord)==PIXELS_PER_ROW-2) v|=BIT_OE;		
-		        
-        // turn off OE after brightness value is reached when displaying MSBs
-        // MSBs always output normal brightness
-        // LSB (!color_depth_idx) outputs normal brightness as MSB from previous row is being displayed
-        if((color_depth_idx > lsbMsbTransitionBit || !color_depth_idx) && ((x_coord) >= brightness)) v|=BIT_OE; // For Brightness
-        
+
+        // need to disable OE after latch to hide row transition
+        // OR one clock before latch, otherwise can get ghosting
+        if((x_coord) == 0 || (x_coord)==PIXELS_PER_ROW-2){ v|=BIT_OE; continue;}
+
+        if((color_depth_idx > lsbMsbTransitionBit || !color_depth_idx) && ((x_coord) >= brightness))
+          {v|=BIT_OE; continue;}// For Brightness
+
         // special case for the bits *after* LSB through (lsbMsbTransitionBit) - OE is output after data is shifted, so need to set OE to fractional brightness
         if(color_depth_idx && color_depth_idx <= lsbMsbTransitionBit) {
           // divide brightness in half for each bit below lsbMsbTransitionBit
           int lsbBrightness = brightness >> (lsbMsbTransitionBit - color_depth_idx + 1);
           if((x_coord) >= lsbBrightness) v|=BIT_OE; // For Brightness
         }
-        
 		/*
 		// Development / testing code only.
 		Serial.printf("r value of %d, color depth: %d, mask: %d\r\n", red,	color_depth_idx, mask);
@@ -620,64 +548,10 @@ void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(int16_t x_coord, int16_t y_coord
 		Serial.printf("val2pwm r value:  %d\r\n", val2PWM(red));
 		if (val2PWM(red) & mask) { Serial.println("Success - PWM"); v|=BIT_R2; }
 		*/
-		
-                 
-        if (painting_top_frame)
-        { // Need to copy what the RGB status is for the bottom pixels
-
-           // Set the color of the pixel of interest
-           if (green & mask) {  v|=BIT_G1; }
-           if (blue & mask)  {  v|=BIT_B1; }
-           if (red & mask)   {  v|=BIT_R1; }
-
-           // Persist what was painted to the other half of the frame equiv. pixel
-           if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_R2)
-                v|=BIT_R2;
-                
-           if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_G2)
-                v|=BIT_G2;
-
-           if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_B2)
-                v|=BIT_B2;
-        }
-        else
-        { // Do it the other way around 
-
-          // Color to set
-          if (red & mask)   { v|=BIT_R2; }
-          if (green & mask) { v|=BIT_G2; }
-          if (blue & mask)  { v|=BIT_B2; }
-          
-          // Copy / persist
-          if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_R1)
-              v|=BIT_R1;
-              
-          if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_G1)
-              v|=BIT_G1;
-          
-          if (p->data[rowBitStruct_x_coord_uint16_t_position] & BIT_B1)
-              v|=BIT_B1; 
-               
-        } // paint
-		
-        // 16 bit parallel mode
-        //Save the calculated value to the bitplane memory in reverse order to account for I2S Tx FIFO mode1 ordering
-		/*
-        if(x_coord%2){
-          p->data[(x_coord)-1] = v;
-        } else {
-          p->data[(x_coord)+1] = v;
-        } // end reordering
-		*/
-
-		// 16 bit parallel mode
-        p->data[rowBitStruct_x_coord_uint16_t_position] = v;		
-		
-          
     } // color depth loop (8)
+		
 
 } // updateMatrixDMABuffer (specific co-ords change)
-#endif	
 
 
 /* Update the entire buffer with a single specific colour - quicker */
@@ -692,91 +566,73 @@ void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint8_t red, uint8_t green, uint
 	blue 	= val2PWM(blue);  
 	*/
 	red 	= lumConvTab[red];
-	green 	= lumConvTab[green];
+	green	= lumConvTab[green];
 	blue 	= lumConvTab[blue]; 	
 
-  for (unsigned int matrix_frame_parallel_row = 0; matrix_frame_parallel_row < ROWS_PER_FRAME; matrix_frame_parallel_row++) // half height - 16 iterations
-  {	
-    for(int color_depth_idx=0; color_depth_idx<PIXEL_COLOR_DEPTH_BITS; color_depth_idx++)  // color depth - 8 iterations
-    {
-        uint16_t mask = (1 << color_depth_idx); // 24 bit color
-        
-        // The destination for the pixel bitstream 
-        //rowBitStruct *p = &matrix_framebuffer_malloc_1[back_buffer_id].rowdata[matrix_frame_parallel_row].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's 
-        rowColorDepthStruct *fb_row_malloc_ptr = (rowColorDepthStruct *) matrix_row_framebuffer_malloc[matrix_frame_parallel_row]; 
-        //Serial.printf("Accessing fb address: %d\r\n", fb_row_malloc_ptr);
-        
-        rowBitStruct *p = &fb_row_malloc_ptr[back_buffer_id].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
+  for(uint8_t color_depth_idx=0; color_depth_idx<PIXEL_COLOR_DEPTH_BITS; color_depth_idx++)  // color depth - 8 iterations
+  {
+    // let's precalculate RGB1 and RGB2 bits than flood it over the entire DMA buffer
+    uint16_t RGBbitfield = 0;
+    uint8_t mask = (1 << color_depth_idx); // 24 bit color
 
-        for(int x_coord=0; x_coord < MATRIX_WIDTH; x_coord++) // row pixel width 64 iterations
-        { 		
-          
-          int v=0; // the output bitstream
-          
-          // if there is no latch to hold address, output ADDX lines directly to GPIO and latch data at end of cycle
-          int gpioRowAddress = matrix_frame_parallel_row;
-          
-          // normally output current rows ADDX, special case for LSB, output previous row's ADDX (as previous row is being displayed for one latch cycle)
-          if(color_depth_idx == 0)
-            gpioRowAddress = matrix_frame_parallel_row-1;
-          
-          if (gpioRowAddress & 0x01) v|=BIT_A; // 1
-          if (gpioRowAddress & 0x02) v|=BIT_B; // 2
-          if (gpioRowAddress & 0x04) v|=BIT_C; // 4
-          if (gpioRowAddress & 0x08) v|=BIT_D; // 8
-          if (gpioRowAddress & 0x10) v|=BIT_E; // 16
-          
-            
-          /* ORIG
-          // need to disable OE after latch to hide row transition
-          if((x_coord) == 0) v|=BIT_OE;
-          
-          // drive latch while shifting out last bit of RGB data
-          if((x_coord) == PIXELS_PER_LATCH-1) v|=BIT_LAT;
-          
-          // need to turn off OE one clock before latch, otherwise can get ghosting
-          if((x_coord)==PIXELS_PER_LATCH-1) v|=BIT_OE;
-          */
-          
-          // need to disable OE after latch to hide row transition
-          if((x_coord) == 0 ) v|=BIT_OE;
-          
+    RGBbitfield |= (bool)(blue & mask);
+    RGBbitfield <<= 1;
+    RGBbitfield |= (bool)(green & mask);
+    RGBbitfield <<= 1;
+    RGBbitfield |= (bool)(red & mask);
+    RGBbitfield |= RGBbitfield << 3;      // now we should have 6 bits of RGB suitable for DMA buffer
+    //Serial.printf("Fill with: 0x%#06x\n", RGBbitfield);
+
+    // iterate rows
+    for (uint16_t matrix_frame_parallel_row = 0; matrix_frame_parallel_row < ROWS_PER_FRAME; matrix_frame_parallel_row++) // half height - 16 iterations
+    {
+      rowColorDepthStruct *fb_row_malloc_ptr = (rowColorDepthStruct *) matrix_row_framebuffer_malloc[matrix_frame_parallel_row]; 
+      //Serial.printf("Accessing fb address: %d\r\n", fb_row_malloc_ptr);
+
+      // The destination for the pixel bitstream
+      rowBitStruct *p = &fb_row_malloc_ptr[back_buffer_id].rowbits[color_depth_idx]; //matrixUpdateFrames location to write to uint16_t's
+
+      // iterate pixels in a row
+      if (fastmode){
+        for(uint16_t x_coord=0; x_coord < MATRIX_WIDTH; x_coord++){
+          uint16_t &v = p->data[(x_coord % 2) ? (x_coord-1):(x_coord+1)]; // take reference to bit vector
+          v &= BITSMASK_RGB12;  // reset color bits
+          v |= RGBbitfield;     // set new color bits
+        }
+      } else {
+        // Set ABCDE address bits vector
+        uint16_t _y = color_depth_idx ? matrix_frame_parallel_row : matrix_frame_parallel_row -1;
+        _y <<=8;    // shift row y-coord to match ABCDE bits in vector from 8 to 12
+
+        for(uint16_t x_coord=0; x_coord < MATRIX_WIDTH; x_coord++){
+          uint16_t &v = p->data[(x_coord % 2) ? (x_coord-1):(x_coord+1)]; // persist what we already have
+          v = RGBbitfield;    // set colot bits and reset all others
+          v|=_y;              // set ABCDE address bits for current row
+
           // drive latch while shifting out last bit of RGB data
           if((x_coord) == PIXELS_PER_ROW-1) v|=BIT_LAT;
-          
-          // need to turn off OE one clock before latch, otherwise can get ghosting
-          if((x_coord)==PIXELS_PER_ROW-2) v|=BIT_OE;	
-          
-          
-          // turn off OE after brightness value is reached when displaying MSBs
-          // MSBs always output normal brightness
-          // LSB (!color_depth_idx) outputs normal brightness as MSB from previous row is being displayed
-          if((color_depth_idx > lsbMsbTransitionBit || !color_depth_idx) && ((x_coord) >= brightness)) v|=BIT_OE; // For Brightness
-          
+
+          // need to disable OE after latch to hide row transition
+          // OR one clock before latch, otherwise can get ghosting
+          if(!x_coord || (x_coord)==PIXELS_PER_ROW-2){
+            v|=BIT_OE; continue;
+          }
+
+          // BRT OE
+          if((color_depth_idx > lsbMsbTransitionBit || !color_depth_idx) && ((x_coord) >= brightness)){
+            v|=BIT_OE; continue;  // For Brightness control
+          }
+
           // special case for the bits *after* LSB through (lsbMsbTransitionBit) - OE is output after data is shifted, so need to set OE to fractional brightness
           if(color_depth_idx && color_depth_idx <= lsbMsbTransitionBit) {
             // divide brightness in half for each bit below lsbMsbTransitionBit
             int lsbBrightness = brightness >> (lsbMsbTransitionBit - color_depth_idx + 1);
             if((x_coord) >= lsbBrightness) v|=BIT_OE; // For Brightness
           }
-          
-          // Top and bottom matrix MATRIX_ROWS_IN_PARALLEL half colours
-          if (green & mask) { v|=BIT_G1; v|=BIT_G2; }
-          if (blue & mask)  { v|=BIT_B1; v|=BIT_B2; }
-          if (red & mask)   { v|=BIT_R1; v|=BIT_R2; }
-          
-          // 16 bit parallel mode
-          //Save the calculated value to the bitplane memory in reverse order to account for I2S Tx FIFO mode1 ordering
-          if(x_coord%2) {
-            p->data[(x_coord)-1] = v;
-          } else {
-            p->data[(x_coord)+1] = v;
-          } // end reordering
-          
-        } // end x_coord iteration
-    } // colour depth loop (8)
-  } // end row iteration
-
+        } // end of x-iterator
+      } // end x_coord iteration
+    } // end row iteration
+  } // colour depth loop (8)
 } // updateMatrixDMABuffer (full frame paint)
 
 /**
@@ -791,7 +647,7 @@ void MatrixPanel_I2S_DMA::shiftDriver(const shift_driver _drv, const int dma_r1_
       #if SERIAL_DEBUG 
         Serial.println( F("MatrixPanel_I2S_DMA - initializing FM6124 driver..."));
       #endif
-      bool REG1[16] = {0,0,0,0,0, 1,1,1,1,1,1, 0,0,0,0,0};    // this sets global matrix brighness power
+      bool REG1[16] = {0,0,0,0,0, 1,1,1,1,1,1, 0,0,0,0,0};    // this sets global matrix brightness power
       bool REG2[16] = {0,0,0,0,0, 0,0,0,0,1,0, 0,0,0,0,0};    // a single bit enables the matrix output
 
       for (uint8_t _pin:{dma_r1_pin, dma_r2_pin, dma_g1_pin, dma_g2_pin, dma_b1_pin, dma_b2_pin, dma_clk_pin, dma_lat_pin, dma_oe_pin})
@@ -807,7 +663,7 @@ void MatrixPanel_I2S_DMA::shiftDriver(const shift_driver _drv, const int dma_r1_
         for (uint8_t _pin:{dma_r1_pin, dma_r2_pin, dma_g1_pin, dma_g2_pin, dma_b1_pin, dma_b2_pin})
           digitalWrite(_pin, REG1[l%16]);   // we have 16 bits shifters and write the same value all over the matrix array
 
-          if (l > MATRIX_WIDTH - 12){         // pull the latch 12 clocks before the end of matrix so that REG1 starts counting to save the value
+          if (l > MATRIX_WIDTH - 12){         // pull the latch 11 clocks before the end of matrix so that REG1 starts counting to save the value
               digitalWrite(dma_lat_pin, HIGH);
           }
           digitalWrite(dma_clk_pin, HIGH);    // 1-clock pulse
@@ -823,7 +679,7 @@ void MatrixPanel_I2S_DMA::shiftDriver(const shift_driver _drv, const int dma_r1_
         for (uint8_t _pin:{dma_r1_pin, dma_r2_pin, dma_g1_pin, dma_g2_pin, dma_b1_pin, dma_b2_pin})
           digitalWrite(_pin, REG2[l%16]);   // we have 16 bits shifters and we write the same value all over the matrix array
 
-          if (l > MATRIX_WIDTH - 13){       // pull the latch 13 clocks before the end of matrix so that reg2 stars counting to save the value
+          if (l > MATRIX_WIDTH - 13){       // pull the latch 12 clocks before the end of matrix so that reg2 stars counting to save the value
               digitalWrite(dma_lat_pin, HIGH);
           }
           digitalWrite(dma_clk_pin, HIGH);  // 1-clock pulse
@@ -839,4 +695,17 @@ void MatrixPanel_I2S_DMA::shiftDriver(const shift_driver _drv, const int dma_r1_
     default:
       break;
     }
+}
+
+/**
+ * clear screen to black and reset service bits
+ */
+void MatrixPanel_I2S_DMA::clearScreen(){
+  if (fastmode) {
+    fastmode = false;       // we always clear screen in 'slow' mode to update all bits in DMA buffer
+    updateMatrixDMABuffer(0, 0, 0);
+    fastmode = true;        // restore fastmode
+  } else {
+    updateMatrixDMABuffer(0, 0, 0);
+  }
 }

--- a/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -303,7 +303,7 @@ class MatrixPanel_I2S_DMA : public Adafruit_GFX {
         while(!i2s_parallel_is_previous_buffer_free()) {}               
     }
     
-    inline void setPanelBrightness(int &b)
+    inline void setPanelBrightness(int b)
     {
       // Change to set the brightness of the display, range of 1 to matrixWidth (i.e. 1 - 64)
         brightness = b;

--- a/FM6126A.md
+++ b/FM6126A.md
@@ -1,0 +1,68 @@
+## The mystery of control registers for FM6126A chips
+
+  
+
+Datasheet for this chis chip is in chineese and does not shed a light on what those two control regs are.
+
+An excellent insight could be found here
+
+https://github.com/hzeller/rpi-rgb-led-matrix/issues/746#issuecomment-453860510
+
+  
+  
+
+So there are two regs - **REG1** and **REG1**,
+
+one could be written with 12 clock pusles (and usually called reg12, dunno why :))
+
+the other one could be written with 13 clock pusles (and usually called reg13, dunno why :))
+
+  
+
+So I've done some measurmens on power consumption while toggling bits of **REG1** and it looks that it could provide a fine grained brighness control over matrix.
+
+There are 6 bits (6 to 11) giving an increased brighness (compared to all-zeroes) and 4 bits (2-5) giving decreased brighness!!!
+
+  
+
+So it seems that the most bright (and hungry for power) value is
+
+bool REG1[16] = {0,0,0,0,0, 1,1,1,1,1,1, 0,0,0,0,0}; and not {0,1,1,1,1, 1,1,1,1,1,1, 1,1,1,1,1} as it is usually used.
+
+I'm not sure about bit 1 - it is either not used or I was unable to measure it's influence to brightness/power.
+
+  
+
+Giving at least 10 bits of hardware brightness control opens pretty nice options for offloading. Should dig into this more deeper.
+
+  
+
+Here are some of the measurments I've took for 2 64x64 panels filled with white color - reg value and corresponding current drain in amps.
+
+  
+
+|REG1 |bit value|Current, amps |
+|--|--|--|
+|REG1| 0111111 00000| >5 amps|
+|REG1| 0100010 00000| 3.890 amp|
+|REG1| 0100000 00000| 3.885 amp|
+|REG1| 0011110 00000| 3.640 amp|
+|REG1| 0011100 00000| 3.620 amp|
+|REG1| 0011000 00000| 3.240 amp|
+|REG1| 0010010 00000| 2.520 amp|
+|REG1| 0010001 00000| 2.518 amp|
+|REG1| 0010001 10000| 2.493 amp|
+|REG1| 0010000 00000| 2.490 amp|
+|REG1| 0010000 11110| 2.214 amp|
+|REG1| 0001100 00000| 2.120 amp|
+|REG1| 0001000 00000| 1.750 amp|
+|REG1| 0000100 00000| 1.375 amp|
+|REG1| 0000010 00000| 1.000 amp|
+|REG1| **0000000 00000**| 0.995 amp|
+|REG1| 0000001 11111| 0.700 amp|
+|REG1| 0000000 01111| 0.690 amp|
+|REG1| 0000000 10000| 0.690 amp|
+|REG1| 0000000 11110| 0.686 amp|
+
+
+/Vortigont/

--- a/examples/AuroraDemo/AuroraDemo.ino
+++ b/examples/AuroraDemo/AuroraDemo.ino
@@ -47,6 +47,19 @@ void setup()
   Serial.begin(115200);
   delay(250);
   matrix.begin(R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN, A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN );  // setup the LED matrix
+  /**
+   * this demos runs pretty fine in fast-mode which gives much better fps on large matrixes (>128x64)
+   * see comments in the lib header on what does that means
+   */
+  //dma_display.setFastMode(true);
+
+  // SETS THE BRIGHTNESS HERE. MAX value is MATRIX_WIDTH, 2/3 OR LOWER IDEAL, default is about 50%
+  // dma_display.setPanelBrightness(30);
+  /* another way to change brightness is to use
+   * dma_display.setPanelBrightness8(uint8_t brt);	// were brt is within range 0-255
+   * it will recalculate to consider matrix width automatically
+   */
+  //dma_display.setPanelBrightness8(180);
 
   Serial.println("**************** Starting Aurora Effects Demo ****************");
 

--- a/examples/AuroraDemo/PatternSwirl.h
+++ b/examples/AuroraDemo/PatternSwirl.h
@@ -44,7 +44,7 @@ class PatternSwirl : public Drawable {
       // Note that we never actually clear the matrix, we just constantly
       // blur it repeatedly.  Since the blurring is 'lossy', there's
       // an automatic trend toward black -- by design.
-      uint8_t blurAmount = beatsin8(2, 10, 255)
+      uint8_t blurAmount = beatsin8(2, 10, 255);
 
 #if FASTLED_VERSION >= 3001000
       blur2d(effects.leds, MATRIX_WIDTH > 255 ? 255 : MATRIX_WIDTH, MATRIX_HEIGHT > 255 ? 255 : MATRIX_HEIGHT, blurAmount);

--- a/fillrate.md
+++ b/fillrate.md
@@ -1,0 +1,25 @@
+## Estimating fillrate
+  
+Here are some results of simple tests on filling DMA buffer with data.
+Filling DMA buffer requres lot's of memory operations on a bit level rather than doing simple byte/word wide store and copy. And it looks like it's quite a task both for esp32 core and compiler. 
+I've done this while optimizing loops and bit logic along with testing compiler results.
+
+So the testbed is:
+ - Matrix modules: 4 x FM6126A based 64x64 modules chained in 256x64
+
+A simple sketch:
+ - allocating single DMA buffs for 256x64
+ - allocating (NUM_LEDS*3) bytes for CRGB buffer
+ - measuring microseconds for the following calls:
+   - clearScreen() - full blanking
+   - fillScreenRGB888() with monochrome/gray colors
+   - filling some gradient into CRGB buff
+   - painting CRGB buff into DMA buff with looped drawPixelRGB888()
+
+|Pattern  |Reference|Ref+SPEED|Optimized|Optimized+SPEED|
+|--|--|--|--|--|
+|fillScreenRGB888()|14570|14570|13400 (8.5% faster)|5520 (164% faster)|
+|CRGB buff fill|760|760|760|760|
+|updateMatrixDMABuffer(CRGB)|7700|32080|55780 (38% faster)|33500(+4.2% slower)|
+
+to be continued...


### PR DESCRIPTION
OK, the more I'm into this lib the more I like it :)
@mrfaptastic, some more changes for you to consider 

- FM6126A init function optimized, the idea is the same, but it is more compact now
- some research on brightness control noted in FM6126A.md

Look like this chip has some really nice features hidden under the hood, like embedded brightness control. Worth a closer look into it but it lacks any documentation and that's frustrating.

GO_FORSPEED now is a runtime 'FAST-mode' (disabled by default)
- ability to change between fast/full refresh modes in runtime via setFastMode(bool) call
- clearScreen() now always does full buffer refresh regardless of the fastmode
- brightnes-control considers fastmode
- brigtness control via setBrightness8(uint8_t) adjusted to matrix width
- updateMatrixDMABuffer(r,g,b) now also runs in fast mode

Also I've done some optimizations here and there into bit-logic/loops, make a difference in some cases.
More details in fillrate.md

|Pattern  |Reference|Ref+SPEED|Optimized|Optimized+SPEED|
|--|--|--|--|--|
|fillScreenRGB888()|14570|14570|13400 (8.5% faster)|5520 (164% faster)|
|CRGB buff fill|760|760|760|760|
|updateMatrixDMABuffer(CRGB)|7700|32080|55780 (38% faster)|33500(+4.2% slower)|

- Some examples updated to reflect the changes.

I've tried to keep API compatible and not to break anything. But since I have only FM6126A
 panels of one size - can't do rigorous testing. Any feedback and ideas highly appreciated.