### PR TITLE
Add missing includes

### DIFF
--- a/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -118,6 +118,7 @@
 
 /***************************************************************************************/
 // Lib includes
+#include <vector>
 #include <memory>
 #include "esp_heap_caps.h"
 #include "esp32_i2s_parallel.h"

--- a/esp32_i2s_parallel.h
+++ b/esp32_i2s_parallel.h
@@ -9,6 +9,7 @@
 extern "C" {
 #endif
 
+#include "driver/gpio.h"
 #include "soc/i2s_struct.h"
 #include "rom/lldesc.h"
 

--- a/esp32_i2s_parallel.h
+++ b/esp32_i2s_parallel.h
@@ -1,7 +1,7 @@
 #ifndef I2S_PARALLEL_H
 #define I2S_PARALLEL_H
 
-#if defined(ESP32)
+#if defined(ESP32) || defined(IDF_VER)
 
 #include <stdint.h>
 
@@ -11,7 +11,7 @@ extern "C" {
 
 #include "driver/gpio.h"
 #include "soc/i2s_struct.h"
-#include "rom/lldesc.h"
+#include "esp32/rom/lldesc.h"
 
 #define DMA_MAX (4096-4)
 //#define DMA_MAX (512)


### PR DESCRIPTION
Without the gpio header you get these errors outside of the Arduino environment:

```
 error: 'GPIO_PIN_MUX_REG' undeclared (first use in this function)
```

Because std::vector is used I also needed to add the vector include to get this to compile with ESP-IDF.