### PR TITLE
CI job to test examples builds

### DIFF
--- a/.github/workflows/pio_build.yml
+++ b/.github/workflows/pio_build.yml
@@ -1,0 +1,48 @@
+# Build examples with Platformio
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# https://docs.platformio.org/en/latest/integration/ci/github-actions.html
+
+name: PlatformIO CI
+
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - "examples/PIO_TestPatterns"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install Platformio
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+        pio update
+    - name: Run PlatformIO
+      env: 
+        PLATFORMIO_CI_SRC: ${{ matrix.example }}
+      run: |
+        pio ci -c ${{ matrix.example }}/platformio.ini

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HUB75 RGB LED matrix library utilizing ESP32 DMA Engine
 
+__[BUILD](/doc/BuildOptions.md) | [EXAMPLES](/examples/README.md)__ | [![PlatformIO CI](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/actions/workflows/pio_build.yml/badge.svg)](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/actions/workflows/pio_build.yml)
+
   **Table of Content**
 
 - [Introduction](#introduction)

--- a/examples/PIO_TestPatterns/platformio.ini
+++ b/examples/PIO_TestPatterns/platformio.ini
@@ -25,18 +25,19 @@ lib_deps =
     https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA.git
 
 
-[env:idfarduino]
-platform = espressif32
-platform_packages =
-  ; use a special branch
-  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#idf-release/v4.0
-framework = arduino, espidf
-build_flags =
-    ${env.build_flags}
-    -DARDUINO=200
-    -DESP32
-    ;-DUSE_FASTLINES
-    -DNO_GFX
-lib_deps =
-    ${env.lib_deps}
-    https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA.git
+; PIO CI can't handle IDF git modules properly (yet)
+;[env:idfarduino]
+;platform = espressif32
+;platform_packages =
+;  ; use a special branch
+;  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#idf-release/v4.4
+;framework = arduino, espidf
+;build_flags =
+;    ${env.build_flags}
+;    -DARDUINO=200
+;    -DESP32
+;    ;-DUSE_FASTLINES
+;    -DNO_GFX
+;lib_deps =
+;    ${env.lib_deps}
+;    https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA.git


### PR DESCRIPTION
Hi @mrfaptastic,
I've made a small CI job to test lib code on new commits/PRs. Currenly only one example tested with PIO configuration. If you like the idea than some other examples could also be converted to PIO format and involved into CI tests. Pls, check this, once merged it should enable "Actions" item in repo's features with a reports being sent to email if any issues found.

Cheers!