### PR TITLE
VirtualMatrixPanel NO_GFX fix

### DIFF
--- a/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -133,7 +133,7 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t &x, int16_t &y) {
 	//Serial.println("Called Base.");
 	coords.x = coords.y = -1; // By defalt use an invalid co-ordinates that will be rejected by updateMatrixDMABuffer
 
-	if ( x < 0 || x >= virtualResX || y < 0 || y >= virtualResY ) { // Co-ordinates go from 0 to X-1 remember! width() and height() are out of range!
+	if ( x < 0 || x >= virtualResX || y < 0 || y >= virtualResY ) { // Co-ordinates go from 0 to X-1 remember! otherwise they are out of range!
 	//Serial.printf("VirtualMatrixPanel::getCoords(): Invalid virtual display coordinate. x,y: %d, %d\r\n", x, y);
 		return coords;
 	}

--- a/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -133,7 +133,7 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t &x, int16_t &y) {
 	//Serial.println("Called Base.");
 	coords.x = coords.y = -1; // By defalt use an invalid co-ordinates that will be rejected by updateMatrixDMABuffer
 
-	if ( x < 0 || x >= width() || y < 0 || y >= height() ) { // Co-ordinates go from 0 to X-1 remember! width() and height() are out of range!
+	if ( x < 0 || x >= virtualResX || y < 0 || y >= virtualResY ) { // Co-ordinates go from 0 to X-1 remember! width() and height() are out of range!
 	//Serial.printf("VirtualMatrixPanel::getCoords(): Invalid virtual display coordinate. x,y: %d, %d\r\n", x, y);
 		return coords;
 	}
@@ -246,9 +246,11 @@ inline void VirtualMatrixPanel::drawPixelRGB888(int16_t x, int16_t y, uint8_t r,
 
 inline void VirtualMatrixPanel::setRotate(bool rotate) {
 	_rotate=rotate;	
-	
+
+#ifndef NO_GFX
 	// We don't support rotation by degrees.
 	if (rotate) { setRotation(1); } else { setRotation(0); }
+#endif
 }
 
 inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate) {


### PR DESCRIPTION
`getCoords` can not access `width()` and `height()` with NO_GFX and `setRotation` is a GFX function so it needs to be part of the `#ifndef NO_GFX` check