### PR TITLE
Update `B` pin in #define to match the table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ However, if you want to change this, simply provide the wanted pin mapping as pa
 #define G2_PIN 12
 #define B2_PIN 13
 #define A_PIN 23
-#define B_PIN 22
+#define B_PIN 19
 #define C_PIN 5
 #define D_PIN 17
 #define E_PIN -1 // required for 1/32 scan panels, like 64x64. Any available pin would do, i.e. IO32


### PR DESCRIPTION
The table shown under "Wiring ESP32 with the LED Matrix Panel" lists `B` pin as connected to IO19.     The section right under it has `#define B_PIN 22`.   This is inconsistent, while the rest of the pins match exactly.