### PR TITLE
Allow refresh rate to be exactly m_cfg.min_refresh_rate

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -108,7 +108,7 @@ bool MatrixPanel_I2S_DMA::setupDMA(const HUB75_I2S_CFG &_cfg)
 
     ESP_LOGW("I2S-DMA", "lsbMsbTransitionBit of %d gives %d Hz refresh rate.", lsbMsbTransitionBit, actualRefreshRate);
 
-    if (actualRefreshRate > m_cfg.min_refresh_rate)
+    if (actualRefreshRate >= m_cfg.min_refresh_rate)
       break;
 
     if (lsbMsbTransitionBit < m_cfg.getPixelColorDepthBits() - 1)


### PR DESCRIPTION
When determing refresh rate and color depth, this loop will keep iterating if the refresh rate ends up being exactly the same as the desired min_refresh_rate. I believe it makes more sense to allow the current lsbMsbTransitionBit/color depth to be used if the calculated refresh rate is exactly the same as the min refresh rate, rather than skipping to the next possible refresh rate and potentially losing color depth.