### PR TITLE
Replace "delete" with "heap_caps_free()" in destructor

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -196,7 +196,7 @@ struct rowBitStruct
 
 #endif
   }
-  ~rowBitStruct() { delete data; }
+  ~rowBitStruct() { heap_caps_free(data); }
 };
 
 /* frameStruct


### PR DESCRIPTION
Replace "delete" with heap_caps_free() since data was not allocated with "new"