### PR TITLE
fix: guard gdma_transfer_config_t behind IDF >= 5.3.0, not 5.1.0

### DIFF
--- a/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
@@ -246,7 +246,7 @@
     };
     gdma_apply_strategy(dma_chan, &strategy_config);
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0) // gdma_transfer_config_t introduced in IDF 5.3
     gdma_transfer_config_t transfer_config = {
 #ifdef SPIRAM_DMA_BUFFER
       .max_data_burst_size = 64,


### PR DESCRIPTION
gdma_transfer_config_t was introduced in ESP-IDF 5.3.0 but the version check used ESP_IDF_VERSION_VAL(5, 1, 0), causing a compile error on any IDF version between 5.1 and 5.2.x where the struct does not exist.

Bumped the guard to ESP_IDF_VERSION_VAL(5, 3, 0) so the block is correctly skipped on IDF 5.1.x and 5.2.x.

Fixes compilation on ESP-IDF 5.2.1 (ESP32-S3 target).