### PR TITLE
Fix: Properly set line_decoder in HUB75_I2S_CFG struct constructor

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -332,7 +332,7 @@ struct HUB75_I2S_CFG
       bool _clockphase = true, 
       uint16_t _min_refresh_rate = 60, 
       uint8_t _pixel_color_depth_bits = PIXEL_COLOR_DEPTH_BITS_DEFAULT) 
-      : mx_width(_w), mx_height(_h), chain_length(_chain), gpio(_pinmap), driver(_drv), double_buff(_dbuff), i2sspeed(_i2sspeed), latch_blanking(_latblk), clkphase(_clockphase), min_refresh_rate(_min_refresh_rate)
+      : mx_width(_w), mx_height(_h), chain_length(_chain), gpio(_pinmap), driver(_drv), line_decoder(_line_drv), double_buff(_dbuff), i2sspeed(_i2sspeed), latch_blanking(_latblk), clkphase(_clockphase), min_refresh_rate(_min_refresh_rate)
   {
     setPixelColorDepthBits(_pixel_color_depth_bits);
   }


### PR DESCRIPTION
This PR fixes a minor typo in the HUB75_I2S_CFG struct constructor. The temporary variable _line_drv is set to TYPE138 by default, but then the line_decoder value is not included in the actual constructor line.

This was causing a very strange issue in one of my projects, where enabling on chip PSRAM (on an ESP32S3) would sometimes result in the row scanning of the display breaking entirely. Every 8th row after the first one would be displayed, with each subsequent row being rendered on top of the previous 8th row.

For whatever reason, with PSRAM enabled on my particular firmware setup, this value was more likely to end up in a section of RAM that was not BSS initialized, and if it ended up set to '3' (or 'SM5266P' mode), the row scanning would break.